### PR TITLE
small change to language-id routing .yaml

### DIFF
--- a/aigw_configs/lab5.yaml
+++ b/aigw_configs/lab5.yaml
@@ -40,11 +40,16 @@ profiles:
           - name: language-id
 
     services:
-      - name: ollama-mistral
+      - name: ollama
+        selector:
+          operand: not 
+          tags:
+            - language:fr
+    
+      - name: ollama/mistral
         selector:
           tags:
-            - "language:fr"
-      - name: ollama
+            - language:fr
 # Here we will find all our processor configuration
 processors:
   - name: language-id


### PR DESCRIPTION
Just a small update to the .yaml to "visually" connect the use of `selectors` and `operands`.

Should work as a direct replacement with labs.

Future examples could include something like:

```yaml
profiles:
- name: language-routing
  limits: []
  inputStages:
    - name: analyze
      steps: 
        - name: language-id

  services:
    - name: ollama/phi
      selector:
        operand: not 
        tags:
          - language:fr
          - language:de

    - name: ollama/llama3
      selector:
        tags:
          - language:fr

    - name: ollama/tiny
      selector:
        tags:
          - language:de
 ```

Where we can show the ability to detect multiple different languages and accordingly.